### PR TITLE
Update apache2.conf

### DIFF
--- a/apache2.conf
+++ b/apache2.conf
@@ -222,8 +222,8 @@ IncludeOptional sites-enabled/*.conf
 Include pf.conf
 Include httpd.conf
 
-LoadModule passenger_module /var/lib/gems/2.1.0/gems/passenger-4.0.57/buildout/apache2/mod_passenger.so
+LoadModule passenger_module /var/lib/gems/2.1.0/gems/passenger-5.0.6/buildout/apache2/mod_passenger.so
 <IfModule mod_passenger.c>
-  PassengerRoot /var/lib/gems/2.1.0/gems/passenger-4.0.57
+  PassengerRoot /var/lib/gems/2.1.0/gems/passenger-5.0.6
   PassengerDefaultRuby /usr/bin/ruby2.1
 </IfModule>


### PR DESCRIPTION
Version of Passenger is sitting at 5.0.6 right now (this should still be updated to not be dependent on version or always install the same version of Passenger)
